### PR TITLE
RunApp will now strip jar file paths only if the jars are located in the 

### DIFF
--- a/src/main/scripts/RunApp.groovy
+++ b/src/main/scripts/RunApp.groovy
@@ -84,7 +84,10 @@ target('runApp': "Runs the application from the command line") {
     javaOpts.each{ debug("  $it") }
 
     def runtimeClasspath = runtimeJars.collect { f ->
-        f.absolutePath - jardir.absolutePath - File.separator
+        if (f.absolutePath.startsWith(jardir.absolutePath))
+	    f.absolutePath - jardir.absolutePath - File.separator
+        else
+            f
     }.join(File.pathSeparator)
 
     runtimeClasspath = [i18nDir, resourcesDir, runtimeClasspath, classesDir, pluginClassesDir].join(File.pathSeparator)


### PR DESCRIPTION
RunApp will now strip jar file paths only if the jars are located in the griffon lib directory.  This allows addition of external jars to the runtime path.
