### PR TITLE
Spelling Error in jumpstart artefact

### DIFF
--- a/src/dist/archetypes/jumpstart/application.groovy
+++ b/src/dist/archetypes/jumpstart/application.groovy
@@ -137,7 +137,7 @@ swing {
             if(!(w instanceof Dialog)) SwingUtils.centerOnScreen(w)
             w.visible = true
         }
-        defualtHide = {w, app ->
+        defaultHide = {w, app ->
             if(w instanceof Dialog || app.windowManager.windows.findAll{it.visible}.size() > 1) {
                 w.dispose()
             } else {


### PR DESCRIPTION
Fixed a spelling error in jumpstart/application.groovy. defaultHide was written defualtHide.
