### PR TITLE
'griffon.project.key' is not replaced in generated build.xml

### DIFF
--- a/src/dist/src/griffon/templates/ide-support/ant/build.xml
+++ b/src/dist/src/griffon/templates/ide-support/ant/build.xml
@@ -1,4 +1,4 @@
-<project name="@griffon.project.key@" default="test">
+<project name="@griffon.project.name@" default="test">
 
     <!-- =================================
           target: clean


### PR DESCRIPTION
Changed to 'griffon.project.name' instead of 'griffon.project.key'.
