### PR TITLE
Changes related to - GRIFFON-484 

### DIFF
--- a/subprojects/griffon-cli/src/main/groovy/org/codehaus/griffon/artifacts/ArtifactInstallEngine.groovy
+++ b/subprojects/griffon-cli/src/main/groovy/org/codehaus/griffon/artifacts/ArtifactInstallEngine.groovy
@@ -45,15 +45,15 @@ import static org.codehaus.griffon.cli.CommandLineConstants.KEY_DISABLE_LOCAL_RE
  */
 class ArtifactInstallEngine {
     private static final Logger LOG = LoggerFactory.getLogger(ArtifactInstallEngine)
-    private static final String INSTALL_FAILURE_KEY = 'griffon.install.failure'
-    private static final String INSTALL_FAILURE_ABORT = 'abort'
-    private static final String INSTALL_FAILURE_CONTINUE = 'continue'
-    private static final String INSTALL_FAILURE_RETRY = 'retry'
+    protected static final String INSTALL_FAILURE_KEY = 'griffon.install.failure'
+    protected static final String INSTALL_FAILURE_ABORT = 'abort'
+    protected static final String INSTALL_FAILURE_CONTINUE = 'continue'
+    protected static final String INSTALL_FAILURE_RETRY = 'retry'
 
-    private final BuildSettings settings
-    private final Metadata metadata
-    private final AntBuilder ant
-    private CommandLineHelper commandLineHelper = new CommandLineHelper(System.out)
+    protected final BuildSettings settings
+    protected final Metadata metadata
+    protected final AntBuilder ant
+    protected CommandLineHelper commandLineHelper = new CommandLineHelper(System.out)
 
     final List installedArtifacts = []
     final List uninstalledArtifacts = []
@@ -251,7 +251,7 @@ class ArtifactInstallEngine {
         }
     }
 
-    private boolean _installPlugins(List<ArtifactDependency> dependencies, ArtifactDependencyResolver resolver) {
+    protected boolean _installPlugins(List<ArtifactDependency> dependencies, ArtifactDependencyResolver resolver) {
         installedArtifacts.clear()
         uninstalledArtifacts.clear()
 
@@ -259,7 +259,7 @@ class ArtifactInstallEngine {
         installPluginsInternal(installPlan)
     }
 
-    private boolean installPluginsInternal(List<ArtifactDependency> installPlan) {
+    protected boolean installPluginsInternal(List<ArtifactDependency> installPlan) {
         List<ArtifactDependency> failedDependencies = []
         List<ArtifactDependency> retryDependencies = []
 
@@ -279,7 +279,7 @@ class ArtifactInstallEngine {
         true
     }
 
-    private void doInstallDependencies(List<ArtifactDependency> dependencies, List<ArtifactDependency> failedDependencies, List<ArtifactDependency> retryDependencies, boolean retryAllowed) {
+    protected void doInstallDependencies(List<ArtifactDependency> dependencies, List<ArtifactDependency> failedDependencies, List<ArtifactDependency> retryDependencies, boolean retryAllowed) {
         String type = Plugin.TYPE
         for (ArtifactDependency dependency: dependencies) {
             try {
@@ -343,7 +343,7 @@ class ArtifactInstallEngine {
         }
     }
 
-    private void _publishReleaseToGriffonLocal(String type, String name, String version, File file) {
+    protected void _publishReleaseToGriffonLocal(String type, String name, String version, File file) {
         String repositoryName = settings.getConfigValue(KEY_DEFAULT_INSTALL_ARTIFACT_REPOSITORY, DEFAULT_LOCAL_NAME)
         ArtifactRepository griffonLocal = ArtifactRepositoryRegistry.instance.findRepository(repositoryName)
 
@@ -394,7 +394,7 @@ class ArtifactInstallEngine {
         }
     }
 
-    private List resolveDependenciesFor(ArtifactDependencyResolver resolver, String type, String name, String version) {
+    protected List resolveDependenciesFor(ArtifactDependencyResolver resolver, String type, String name, String version) {
         List<ArtifactDependency> dependencies = []
         try {
             dependencies << resolver.resolveDependencyTree(type, name, version)
@@ -410,7 +410,7 @@ class ArtifactInstallEngine {
         dependencies
     }
 
-    private List<ArtifactDependency> resolveDependenciesFor(List<ArtifactDependency> dependencies, ArtifactDependencyResolver resolver) {
+    protected List<ArtifactDependency> resolveDependenciesFor(List<ArtifactDependency> dependencies, ArtifactDependencyResolver resolver) {
         Map<String, Release> installedReleases = getInstalledReleases(Plugin.TYPE)
 
         Map<String, ArtifactDependency> installedDependencies = [:]
@@ -465,7 +465,7 @@ class ArtifactInstallEngine {
         installPlan
     }
 
-    private String printDependencyTree(ArtifactDependency artifactDependency, boolean trim = false) {
+    protected String printDependencyTree(ArtifactDependency artifactDependency, boolean trim = false) {
         ByteArrayOutputStream baos = new ByteArrayOutputStream()
         PrintStream out = new PrintStream(baos)
         artifactDependency.printout(0i, out, true)
@@ -546,7 +546,7 @@ class ArtifactInstallEngine {
     }
 
     // TODO LEGACY - remove before 1.0
-    private void generateDependencyDescriptorFor(String pluginDirPath, String name, String version) {
+    protected void generateDependencyDescriptorFor(String pluginDirPath, String name, String version) {
         File addonJar = new File(pluginDirPath, "addon/griffon-${name}-addon-${version}.jar")
         File cliJar = new File(pluginDirPath, "addon/griffon-${name}-cli-${version}.jar")
         File testJar = new File(pluginDirPath, "dist/griffon-${name}-${version}-test.jar")
@@ -582,7 +582,7 @@ class ArtifactInstallEngine {
         }
     }
 
-    private void resolvePluginJarDependencies(String pluginInstallPath, String pluginName, String pluginVersion) {
+    protected void resolvePluginJarDependencies(String pluginInstallPath, String pluginName, String pluginVersion) {
         List<File> dependencyDescriptors = [
                 new File("$pluginInstallPath/dependencies.groovy"),
                 new File("$pluginInstallPath/plugin-dependencies.groovy")
@@ -622,7 +622,7 @@ class ArtifactInstallEngine {
         }
     }
 
-    private boolean doUninstall(String type, String name, String version = null) {
+    protected boolean doUninstall(String type, String name, String version = null) {
         String metadataKey = ''
         File artifactDir = null
 
@@ -661,7 +661,7 @@ class ArtifactInstallEngine {
         false
     }
 
-    private Release inspectArtifactRelease(String type, File file) {
+    protected Release inspectArtifactRelease(String type, File file) {
         Release release = createReleaseFromMetadata(type, file)
         String artifactNameAndVersion = "${release.artifact.name}-${release.version}"
 
@@ -706,7 +706,7 @@ class ArtifactInstallEngine {
         release
     }
 
-    private Release createReleaseFromMetadata(String type, File file) {
+    protected Release createReleaseFromMetadata(String type, File file) {
         try {
             ArtifactUtils.createReleaseFromMetadata(type, file)
         } catch (IllegalArgumentException iae) {
@@ -714,7 +714,7 @@ class ArtifactInstallEngine {
         }
     }
 
-    private void displayNewScripts(String pluginName, installPath) {
+    protected void displayNewScripts(String pluginName, installPath) {
         def providedScripts = new File("${installPath}/scripts").listFiles().findAll { !it.name.startsWith('_') && it.name.endsWith('.groovy')}
         if (providedScripts) {
             String legend = "Plugin ${pluginName} provides the following new scripts:"
@@ -726,7 +726,7 @@ class ArtifactInstallEngine {
         }
     }
 
-    private void runPluginScript(File scriptFile, fullPluginName, msg) {
+    protected void runPluginScript(File scriptFile, fullPluginName, msg) {
         if (pluginScriptRunner != null) {
             if (pluginScriptRunner.maximumNumberOfParameters < 3) {
                 throw new IllegalStateException("The [pluginScriptRunner] closure property must accept at least 3 arguments")

--- a/subprojects/griffon-cli/src/main/groovy/org/codehaus/griffon/artifacts/DependencyUnrslvdArtifactInstallEngine.groovy
+++ b/subprojects/griffon-cli/src/main/groovy/org/codehaus/griffon/artifacts/DependencyUnrslvdArtifactInstallEngine.groovy
@@ -1,0 +1,201 @@
+/*
+ * Copyright 2011-2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.codehaus.griffon.artifacts
+
+import griffon.util.BuildSettings
+import griffon.util.Metadata
+import org.codehaus.griffon.artifacts.model.Archetype
+import org.codehaus.griffon.artifacts.model.Plugin
+import org.codehaus.griffon.artifacts.model.Release
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import static griffon.util.GriffonExceptionHandler.sanitize
+import static griffon.util.GriffonNameUtils.capitalize
+import static griffon.util.GriffonNameUtils.getPropertyNameForLowerCaseHyphenSeparatedName
+import static org.codehaus.griffon.artifacts.ArtifactUtils.*
+
+/**
+ * Created by IntelliJ IDEA.
+ * User: m29625
+ * Date: 4/1/12
+ * Time: 6:16 PM
+ * To change this template use File | Settings | File Templates.
+ */
+class DependencyUnrslvdArtifactInstallEngine extends ArtifactInstallEngine {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DependencyUnrslvdArtifactInstallEngine)
+
+    DependencyUnrslvdArtifactInstallEngine(BuildSettings settings, Metadata metadata, AntBuilder ant) {
+        super(settings, metadata, ant)
+        this.settings = settings
+        this.metadata = metadata
+        this.ant = ant
+    }
+
+    boolean installPluginWithoutDependency() {
+        Map<String, String> registeredPlugins = getRegisteredArtifacts(Plugin.TYPE, metadata)
+        Map<String, String> installedPlugins = getInstalledArtifacts(Plugin.TYPE)
+
+        File pluginDescriptor = settings.isPluginProject()
+        if (pluginDescriptor) {
+            GroovyClassLoader gcl = new GroovyClassLoader(getClass().classLoader)
+            gcl.addURL(settings.baseDir.toURI().toURL())
+            String artifactClassName = pluginDescriptor.name[0..-8]
+            def plugin = gcl.loadClass(artifactClassName).newInstance()
+            plugin.dependsOn.each { name, version ->
+                registeredPlugins[name] = version.toString()
+            }
+        }
+
+        if (LOG.debugEnabled) {
+            String registered = registeredPlugins.collect([]) {k, v -> "${k}-${v}"}.join('\n\t')
+            if (registered) LOG.debug("Registered plugins:\n\t${registered}")
+            String installed = installedPlugins.collect([]) {k, v -> "${k}-${v}"}.join('\n\t')
+            if (installed) LOG.debug("Installed plugins:\n\t${installed}")
+        }
+
+        Map<String, String> pluginsToDelete = [:]
+        Map<String, String> missingPlugins = [:]
+        registeredPlugins.each { name, version ->
+            String v = installedPlugins[name]
+            if (version.endsWith('-SNAPSHOT') || v != version) {
+                missingPlugins[name] = version
+            }
+        }
+
+        installedPlugins.each { name, version ->
+            String v = registeredPlugins[name]
+            if (v != version) {
+                pluginsToDelete[name] = version
+            }
+        }
+
+        if (installedPlugins) {
+            installedPlugins.each { name, version ->
+                metadata["plugins.${name}"] = version
+            }
+            metadata.persist()
+        }
+
+        if (LOG.debugEnabled) {
+            String installed = installedPlugins.collect([]) {k, v -> "${k}-${v}"}.join('\n\t')
+            if (installed) LOG.debug("Installed plugins (confirmed):\n\t${installed}")
+            String missing = missingPlugins.collect([]) {k, v -> "${k}-${v}"}.join('\n\t')
+            if (missing) LOG.debug("Missing plugins:\n\t${missing}")
+            String todelete = pluginsToDelete.collect([]) {k, v -> "${k}-${v}"}.join('\n\t')
+            if (todelete) LOG.debug("Plugins to be deleted:\n\t${todelete}")
+        }
+
+        pluginsToDelete.each { name, version ->
+            if (!version.endsWith('-SNAPSHOT')) eventHandler 'StatusUpdate', "Plugin ${name}-${version} is installed, but was not found in the application's metadata. Removing this plugin from the application's plugin base"
+            ant.delete(dir: getInstallPathFor(Plugin.TYPE, name, version), failonerror: false)
+            installedPlugins.remove(name)
+        }
+
+        if (!missingPlugins) {
+            return true
+        }
+
+        ArtifactDependencyResolver resolver = new ArtifactDependencyResolver()
+        List<ArtifactDependency> dependencies = []
+        try {
+            dependencies = resolver.resolveDependencyTree(Plugin.TYPE, missingPlugins)
+        } catch (Exception e) {
+            sanitize(e)
+            eventHandler 'StatusError', "Some missing plugins failed to resolve => $e"
+            errorHandler "Cannot continue with unresolved dependencies."
+        }
+
+        if (LOG.debugEnabled && dependencies) {
+            LOG.debug("Dependency resolution outcome:\n${dependencies.collect([]) {printDependencyTree(it, true)}.join('\n')}")
+        }
+
+        try {
+            return _installPlugins(dependencies, resolver)
+        } catch (InstallArtifactException iae) {
+            errorHandler "Could not resolve plugin dependencies."
+        }
+    }
+
+    void installFromFile(String type, File file, boolean resolveDependencies = false) {
+        Release release = inspectArtifactRelease(type, file)
+
+        String artifactName = release.artifact.name
+        String releaseVersion = release.version
+        String releaseName = "${artifactName}-${releaseVersion}"
+        String artifactInstallPath = "${artifactBase(type)}/${releaseName}"
+
+        if (resolveDependencies && type == Plugin.TYPE) {
+            if (release.dependencies) {
+                Map<String, String> plugins = [:]
+                release.dependencies.each { entry ->
+                    plugins[entry.name] = entry.version
+                }
+                if (!installPlugins(plugins)) {
+                    throw new InstallArtifactException("Could not install plugin ${releaseName}")
+                }
+            }
+        }
+
+        if (!release.snapshot && new File(artifactInstallPath).exists()) {
+            if (!commandLineHelper.confirmInput("${capitalize(type)} '${releaseName}' is already installed. Overwrite?")) {
+                return
+            }
+        }
+
+        eventHandler 'StatusUpdate', "Software license of ${releaseName} is '${release.artifact.license}'"
+
+        for (dir in findAllArtifactDirsForName(type, artifactName)) {
+            ant.delete(dir: dir, failonerror: false)
+        }
+        ant.mkdir(dir: artifactInstallPath)
+        ant.unzip(dest: artifactInstallPath, src: file)
+
+        switch (type) {
+            case Plugin.TYPE:
+                variableStore["${getPropertyNameForLowerCaseHyphenSeparatedName(artifactName)}PluginDir"] = new File(artifactInstallPath).absoluteFile
+                variableStore["${getPropertyNameForLowerCaseHyphenSeparatedName(artifactName)}PluginVersion"] = releaseVersion
+                // TODO LEGACY - remove before 1.0
+                if (new File(artifactInstallPath, 'plugin.xml').exists()) {
+                    generateDependencyDescriptorFor(artifactInstallPath, artifactName, releaseVersion)
+                }
+
+                if (!settings.isPluginProject()) {
+                    def installScript = new File("${artifactInstallPath}/scripts/_Install.groovy")
+                    runPluginScript(installScript, releaseName, 'post-install script')
+                }
+                displayNewScripts(releaseName, artifactInstallPath)
+                break
+            case Archetype.TYPE:
+                break
+        }
+
+        if (settings.isGriffonProject() && !settings.isArchetypeProject() && type == Plugin.TYPE) {
+            // Metadata.reload()
+            metadata["${type}s." + artifactName] = releaseVersion
+            metadata.persist()
+            Metadata.reload()
+        }
+
+        if (!installedArtifacts.contains(artifactInstallPath)) {
+            installedArtifacts << artifactInstallPath
+        }
+
+        eventHandler "${capitalize(type)}Installed", [type, artifactName, releaseVersion, artifactInstallPath]
+        eventHandler 'StatusFinal', "Installed ${type} '${releaseName}' in ${artifactInstallPath}"
+    }
+}

--- a/subprojects/griffon-scripts/src/main/groovy/_GriffonClean.groovy
+++ b/subprojects/griffon-scripts/src/main/groovy/_GriffonClean.groovy
@@ -26,16 +26,16 @@ _griffon_clean_called = true
 
 // includeTargets << griffonScript("_GriffonEvents")
 
-target(name: 'cleanAll', description: "Cleans a Griffon project", prehook: null, posthook: null) {
+target(cleanAll: "Cleans a Griffon project") {
     clean()
     cleanTestReports()
 }
 
-target(name: 'clean', description: "Implementation of clean", prehook: null, posthook: null) {
+target(clean: "Implementation of clean") {
     depends(cleanCompiledSources, cleanPackaging)
 }
 
-target(name: 'cleanCompiledSources', description: "Cleans compiled Java and Groovy sources", prehook: null, posthook: null) {
+target(cleanCompiledSources: "Cleans compiled Java and Groovy sources") {
     [
             projectCliClassesDir,
             projectMainClassesDir,
@@ -48,7 +48,7 @@ target(name: 'cleanCompiledSources', description: "Cleans compiled Java and Groo
     }
 }
 
-target(name: 'cleanTestReports', description: "Cleans the test reports", prehook: null, posthook: null) {
+target(cleanTestReports: "Cleans the test reports") {
     // Delete all reports *except* TEST-TestSuites.xml which we need
     // for the "--rerun" option to work.
     ant.delete(failonerror: false, includeemptydirs: true) {
@@ -59,7 +59,7 @@ target(name: 'cleanTestReports', description: "Cleans the test reports", prehook
     }
 }
 
-target(name: 'cleanPackaging', description: "Cleans the distribtion directories", prehook: null, posthook: null) {
+target(cleanPackaging: "Cleans the distribtion directories") {
     if (buildConfigFile.exists()) {
         def cfg = configSlurper.parse(buildConfigFile.toURL())
         cfg.setConfigFile(buildConfigFile.toURL())

--- a/subprojects/griffon-scripts/src/main/groovy/_GriffonCompile.groovy
+++ b/subprojects/griffon-scripts/src/main/groovy/_GriffonCompile.groovy
@@ -23,20 +23,12 @@ import org.codehaus.groovy.runtime.StackTraceUtils
  */
 
 includeTargets << griffonScript('_GriffonClasspath')
+includeTargets << griffonScript('_GriffonResolveDependencies')
 
 ant.taskdef(name: 'groovyc', classname: 'org.codehaus.groovy.ant.Groovyc')
 ant.taskdef(name: 'griffonc', classname: 'org.codehaus.griffon.compiler.GriffonCompiler')
 
 additionalSources = []
-
-compilerOptions = { Map options ->
-    if (griffonSettings.sourceEncoding != null) options.encoding = griffonSettings.sourceEncoding
-    if (griffonSettings.compilerDebug != null) options.debug = griffonSettings.compilerDebug
-    if (griffonSettings.compilerSourceLevel != null) options.source = griffonSettings.compilerSourceLevel
-    if (griffonSettings.compilerTargetLevel != null) options.target = griffonSettings.compilerTargetLevel
-    debug "Javac options $options"
-    options
-}
 
 compilerPaths = { String classpathId ->
     def excludedPaths = ["resources", "i18n", "conf"] // conf gets special handling
@@ -54,7 +46,11 @@ compilerPaths = { String classpathId ->
         if (new File(srcPath).exists()) src(path: srcPath)
     }
 
-    javac(compilerOptions(classpathref: classpathId))
+    javac(classpathref: classpathId,
+            encoding: griffonSettings.sourceEncoding,
+            debug: 'yes',
+            source: griffonSettings.compilerSourceLevel,
+            target: griffonSettings.compilerTargetLevel)
 }
 
 compileSources = { destinationDir, classpathId, sources ->
@@ -88,12 +84,7 @@ compileSources = { destinationDir, classpathId, sources ->
 
 target(name: 'compile', description: "Implementation of compilation phase",
         prehook: null, posthook: null) {
-    def compileDependencies = [classpath]
-    if (argsMap.clean) {
-        includeTargets << griffonScript('_GriffonClean')
-        compileDependencies = [clean] + compileDependencies
-    }
-    depends(* compileDependencies)
+    depends(classpath, resolveDependenciesAtCompile)
 
     if (isApplicationProject || isPluginProject) {
         [
@@ -126,7 +117,11 @@ target(name: 'compile', description: "Implementation of compilation phase",
             src(path: "${basedir}/griffon-app/conf")
             include(name: '*.groovy')
             include(name: '*.java')
-            javac(compilerOptions(classpathref: classpathId))
+            javac(classpathref: classpathId,
+                    encoding: griffonSettings.sourceEncoding,
+                    debug: 'yes',
+                    source: griffonSettings.compilerSourceLevel,
+                    target: griffonSettings.compilerTargetLevel)
         }
         ant.copy(todir: projectMainClassesDir) {
             fileset(dir: "${basedir}/griffon-app/conf") {
@@ -145,7 +140,11 @@ target(name: 'compile', description: "Implementation of compilation phase",
                 }
                 compileSources(projectCliClassesDir, 'plugin.cli.compile.classpath') {
                     src(path: cliSourceDir)
-                    javac(compilerOptions(classpathref: 'plugin.cli.compile.classpath'))
+                    javac(classpathref: 'plugin.cli.compile.classpath',
+                            encoding: griffonSettings.sourceEncoding,
+                            debug: 'yes',
+                            source: griffonSettings.compilerSourceLevel,
+                            target: griffonSettings.compilerTargetLevel)
                 }
                 ant.copy(todir: projectCliClassesDir) {
                     fileset(dir: "${basedir}/src/cli") {
@@ -166,7 +165,11 @@ target(name: 'compile', description: "Implementation of compilation phase",
                 src(path: basedir)
                 include(name: '*GriffonAddon.groovy')
                 include(name: '*GriffonAddon.java')
-                javac(compilerOptions(classpathref: 'addon.classpath'))
+                javac(classpathref: 'addon.classpath',
+                        encoding: griffonSettings.sourceEncoding,
+                        debug: 'yes',
+                        source: griffonSettings.compilerSourceLevel,
+                        target: griffonSettings.compilerTargetLevel)
             }
         }
     }
@@ -201,7 +204,11 @@ compileProjectTestSrc = { rootDir ->
             }
             compileSources(projectTestClassesDir, 'projectTest.classpath') {
                 src(path: projectTest)
-                javac(compilerOptions(classpathref: 'projectTest.classpath'))
+                javac(classpathref: 'projectTest.classpath',
+                        encoding: griffonSettings.sourceEncoding,
+                        debug: 'yes',
+                        source: griffonSettings.compilerSourceLevel,
+                        target: griffonSettings.compilerTargetLevel)
             }
         }
     }

--- a/subprojects/griffon-scripts/src/main/groovy/_GriffonResolveDependencies.groovy
+++ b/subprojects/griffon-scripts/src/main/groovy/_GriffonResolveDependencies.groovy
@@ -31,10 +31,28 @@ includeTargets << griffonScript('_GriffonArtifacts')
 
 runDependencyResolution = true
 target(name: 'resolveDependencies', description: 'Resolves project and plugin dependencies',
-    prehook: null, posthook: null) {
+        prehook: null, posthook: null) {
+
+
     if(!griffonSettings.isGriffonProject()) return
 
     if (runDependencyResolution) {
+        long start = System.currentTimeMillis()
+        event 'StatusUpdate', ['Resolving plugin dependencies']
+        ArtifactInstallEngine artifactInstallEngine = createDpndcyUnrslvdArtifactInstallEngine()
+        artifactInstallEngine.installPluginWithoutDependency()
+//XXX -- NATIVE
+        runDependencyResolution = false
+//
+    }
+}
+
+runDependencyResolution = true
+target(name: 'resolveDependenciesAtCompile', description: 'Resolves project and plugin dependencies at compile time',
+        prehook: null, posthook: null) {
+      if(!griffonSettings.isGriffonProject()) return
+
+      if (runDependencyResolution) {
         long start = System.currentTimeMillis()
         event 'StatusUpdate', ['Resolving plugin dependencies']
         ArtifactInstallEngine artifactInstallEngine = createArtifactInstallEngine()
@@ -47,7 +65,7 @@ target(name: 'resolveDependencies', description: 'Resolves project and plugin de
         long end = System.currentTimeMillis()
         event 'StatusFinal', ["Plugin dependencies resolved in ${end - start} ms."]
 
-// XXX -- NATIVE
+    //XXX -- NATIVE
         Map<String, List<File>> jars = [:]
         processPlatformLibraries(jars, platform)
         if (is64Bit) {
@@ -60,11 +78,11 @@ target(name: 'resolveDependencies', description: 'Resolves project and plugin de
             griffonSettings.updateDependenciesFor 'runtime', files
             griffonSettings.updateDependenciesFor 'test', files
         }
-// XXX -- NATIVE
+    //XXX -- NATIVE
         runDependencyResolution = false
-        // reset appName
+    //        reset appName
         if(metadata) griffonAppName = metadata.getApplicationName()
-    }
+       }
 }
 
 // XXX -- NATIVE

--- a/subprojects/griffon-scripts/src/main/groovy/_GriffonSettings.groovy
+++ b/subprojects/griffon-scripts/src/main/groovy/_GriffonSettings.groovy
@@ -368,7 +368,6 @@ loadArtifactDescriptorClass = { String artifactFile ->
         // directory to the class loader in case it didn't exist before
         // the associated descriptor's sources were compiled.
         def gcl = new GroovyClassLoader(classLoader)
-        gcl.addURL(griffonSettings.baseDir.toURI().toURL())
         String artifactClassName = artifactFile.endsWith('.groovy') ? artifactFile[0..-8] : artifactFile
         return gcl.loadClass(artifactClassName).newInstance()
     }
@@ -444,7 +443,7 @@ target(updateAppProperties: "Updates default application.properties") {
     appGriffonVersion = griffonVersion
 }
 
-buildConfig.griffon.application.mainClass = buildConfig.griffon.application.mainClass ?: 'griffon.test.mock.MockGriffonApplication'
+buildConfig.griffon.application.mainClass = buildConfig.griffon.application.mainClass ?: 'griffon.swing.SwingApplication'
 
 resetDependencyResolution = {
     pluginSettings.clearCaches()


### PR DESCRIPTION
These are changes related to:

GRIFFON-484  - Griffon 0.9.5-rc2 does dependency resolution of plugins programatically which fails during compilation for plugins with incorrect dependency syntax

This gives the developer the option of not doing dependency resolutions during clean or other non-compile related operations.   Dependency resolution for plugins is performed only at compile time
