### PR TITLE
Pass main args array to scripts

### DIFF
--- a/src/dist/bin/startGriffon
+++ b/src/dist/bin/startGriffon
@@ -50,8 +50,6 @@ if [ "$1" = "-cp" ] || [ "$1" = "-classpath" ]; then
   shift 2
 fi
 
-ARGUMENTS=$@
-
 # Attempt to set JAVA_HOME if it's not already set
 if [ -z "$JAVA_HOME" ]; then
 
@@ -251,6 +249,7 @@ startGriffon() {
           --conf "$GROOVY_CONF" \
           --classpath "$CP"
   	else
+      if $cygwin ; then            # @ have been preprocessed into ARGUMENTS
          exec "$JAVACMD" $JAVA_OPTS \
           -classpath "$STARTER_CLASSPATH" \
           -Dprogram.name="$PROGNAME" \
@@ -264,6 +263,21 @@ startGriffon() {
           --conf "$GROOVY_CONF" \
           --classpath "$CP" \
           "${ARGUMENTS}"
+      else                         # we need @ to be expanded into separte words
+         exec "$JAVACMD" $JAVA_OPTS \
+          -classpath "$STARTER_CLASSPATH" \
+          -Dprogram.name="$PROGNAME" \
+          -Dgroovy.starter.conf="$GROOVY_CONF" \
+          -Dgriffon.home="$GRIFFON_HOME" \
+          -Dbase.dir="." \
+          -Dtools.jar="$TOOLS_JAR" \
+          -Dgroovy.sanitized.stacktraces="$STACKTRACE_FILTERS" \
+          $STARTER_MAIN_CLASS \
+          --main $CLASS \
+          --conf "$GROOVY_CONF" \
+          --classpath "$CP" \
+          "$@"
+      fi
   	fi
   fi
 }

--- a/subprojects/griffon-cli/src/main/groovy/org/codehaus/griffon/cli/GriffonScriptRunner.java
+++ b/subprojects/griffon-cli/src/main/groovy/org/codehaus/griffon/cli/GriffonScriptRunner.java
@@ -78,6 +78,7 @@ public class GriffonScriptRunner {
     public static final String VAR_SCRIPT_FILE = "scriptFile";
     public static final String VAR_SCRIPT_ENV = "scriptEnv";
     public static final String VAR_SCRIPT_ARGS_MAP = "argsMap";
+    public static final String VAR_SCRIPT_UNPARSED_ARGS = "unparsedArgs";
     public static final String KEY_SCRIPT_ARGS = "griffon.cli.args";
 
     /**
@@ -96,6 +97,9 @@ public class GriffonScriptRunner {
         // available.
         String griffonHome = System.getProperty("griffon.home");
         ScriptAndArgs script = processArgumentsAndReturnScriptName(commandLine);
+
+        // Remember unparsed commandline args for the benefit of scripts that want to process them
+        script.unparsedArgs = args;
 
         if (commandLine.hasOption(CommandLine.HELP_ARGUMENT)) {
             System.out.println(getCommandLineParser().getHelpMessage());
@@ -377,6 +381,7 @@ public class GriffonScriptRunner {
                 binding.setVariable(VAR_SCRIPT_NAME, scriptFileName);
                 binding.setVariable(VAR_SCRIPT_FILE, scriptFile);
                 binding.setVariable(VAR_SCRIPT_ARGS_MAP, script.options);
+                binding.setVariable(VAR_SCRIPT_UNPARSED_ARGS, script.unparsedArgs);
                 script.name = scriptFileName;
 
                 // Setup the script to call.
@@ -413,6 +418,7 @@ public class GriffonScriptRunner {
             binding.setVariable(VAR_SCRIPT_NAME, scriptFileName);
             binding.setVariable(VAR_SCRIPT_FILE, scriptFile);
             binding.setVariable(VAR_SCRIPT_ARGS_MAP, script.options);
+            binding.setVariable(VAR_SCRIPT_UNPARSED_ARGS, script.unparsedArgs);
             script.name = scriptFileName;
 
             // Set up the script to call.
@@ -435,6 +441,7 @@ public class GriffonScriptRunner {
         String scriptName = script.name;
         binding.setVariable(VAR_SCRIPT_NAME, scriptName);
         binding.setVariable(VAR_SCRIPT_ARGS_MAP, script.options);
+        binding.setVariable(VAR_SCRIPT_UNPARSED_ARGS, script.unparsedArgs);
 
         try {
             loadScriptClass(gant, scriptName);
@@ -857,6 +864,7 @@ public class GriffonScriptRunner {
     private static class ScriptAndArgs {
         public String name;
         public String env;
+        public String[] unparsedArgs;
         public List<String> params = new ArrayList<String>();
         public Map<String, Object> options = new LinkedHashMap<String, Object>();
     }


### PR DESCRIPTION
Changes to make it possible to parse a script's command line with something like groovy.util.CliBuilder :

Make sure parameters passed to the GriffonScriptRunner are separate elements as build up the shell interpreter so the String[] args array in main is intact.
Put this args array into the script binding under the property 'unparsedArgs'.
