### PR TITLE
Detect OS X JDK using /usr/libexec/java_home

### DIFF
--- a/src/dist/bin/startGriffon
+++ b/src/dist/bin/startGriffon
@@ -58,6 +58,9 @@ if [ -z "$JAVA_HOME" ]; then
 	# Set JAVA_HOME for Darwin
 	if $darwin; then
 
+    [ -z "$JAVA_HOME" -a -f "/usr/libexec/java_home" ] &&
+      export JAVA_HOME=`/usr/libexec/java_home`
+
 		[ -z "$JAVA_HOME" -a -d "/Library/Java/Home" ] &&
 			export JAVA_HOME="/Library/Java/Home"
 


### PR DESCRIPTION
On my machine, CurrentJDK is not updated to point to Java 7
when I change the Java Preferences list order.

Therefore, the current symbolic link checking method does
not work, and returns Java 6.  Using /usr/libexec/java_home
seems to work (at least for me)
