### PR TITLE
Changed handling of numbers in project names

### DIFF
--- a/templates/griffon-standard-templates/templates/griffon-javafx-groovy/lazybones.groovy
+++ b/templates/griffon-standard-templates/templates/griffon-javafx-groovy/lazybones.groovy
@@ -2,9 +2,9 @@ import uk.co.cacoethes.util.NameType
 
 Map props = [:]
 File projectDir = targetDir instanceof File ? targetDir : new File(String.valueOf(targetDir))
-props.project_name = transformText(projectDir.name, from: NameType.CAMEL_CASE, to: NameType.HYPHENATED)
+props.project_name = transformText(projectDir.name, from: NameType.NATURAL, to: NameType.HYPHENATED)
 props.project_property_name = transformText(props.project_name, from: NameType.HYPHENATED, to: NameType.PROPERTY)
-props.project_capitalized_name = props.project_property_name.capitalize()
+props.project_capitalized_name = transformText(props.project_name, from: NameType.HYPHENATED, to: NameType.CAMEL_CASE).replaceAll(/[.-]/,'')
 props.project_group = ask("Define value for 'group' [org.example]: ", "org.example", "group")
 props.project_version = ask("Define value for 'version' [0.1.0-SNAPSHOT]: ", "0.1.0-SNAPSHOT", "version")
 props.project_package = ask("Define value for 'package' ["+ props.project_group +"]: ", props.project_group, "package")


### PR DESCRIPTION
Hi,
the lazybones templates create uncompilable classnames if there are numbers and/or hyphens in the project name. This is just a little fix for these names. And currently only for the javafx-groovy template. If the changes are ok, I may provide the fix for the other templates too.
