### PR TITLE
Fix typo in Quick Start section

### DIFF
--- a/docs/griffon-site/src/jbake/templates/index.gsp
+++ b/docs/griffon-site/src/jbake/templates/index.gsp
@@ -60,7 +60,7 @@
 </div>
 <div class="paragraph">
 <p>Next register the <code>griffon-lazybones-templates</code> repository with Lazybones'
-config file. Edit <code>\$USER_HOME/.lazybones.config.groovy</code></p>
+config file. Edit <code>\$USER_HOME/.lazybones/config.groovy</code></p>
 </div>
 <div class="listingblock">
 <div class="content">


### PR DESCRIPTION
Corrected file path for lazybones config file.
