### PR TITLE
fixed typo in call to renameFile closure

### DIFF
--- a/templates/griffon-standard-templates/templates/griffon-plugin/lazybones.groovy
+++ b/templates/griffon-standard-templates/templates/griffon-plugin/lazybones.groovy
@@ -60,7 +60,7 @@ def renameFile = { File from, String path ->
 }
 
 mainSources.eachFile { File file ->
-    renamefile(file, mainSourcesPath.absolutePath + '/' + props.project_class_name + file.name)
+    renameFile(file, mainSourcesPath.absolutePath + '/' + props.project_class_name + file.name)
 }
 
 File pluginDir = new File(projectDir, 'subprojects/plugin')


### PR DESCRIPTION
When using lazybones create griffon-plugin, I got

"Post install script caused an exception, project might be corrupt:
No signature of method: lazybones.renamefile() is applicable for
argument types: (java.io.File, java.lang.String) values:
[foo/subprojects/plugin/src/main/java/Module.java,
/home/tobias/tmp/foo/subprojects/plugin/src/main/java/org/codehaus/griffon/runtime/foo/FooModule.java]"
fixes #31
