### PR TITLE
Do not use File.separator to get resources from the classloader.

### DIFF
--- a/subprojects/griffon-core/src/main/java/griffon/util/ServiceLoaderUtils.java
+++ b/subprojects/griffon-core/src/main/java/griffon/util/ServiceLoaderUtils.java
@@ -19,7 +19,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
-import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.util.Enumeration;
@@ -50,13 +49,15 @@ public class ServiceLoaderUtils {
         requireNonBlank(path, "Argument 'path' must not be blank");
         requireNonNull(type, "Argument 'type' must not be null");
         requireNonNull(processor, "Argument 'processor' must not be null");
-        String normalizedPath = path.endsWith(File.separator) ? path : path + File.separator;
+        // "The name of a resource is a /-separated path name that identifies the resource."
+        String normalizedPath = path.endsWith("/") ? path : path + "/";
 
         Enumeration<URL> urls;
 
         try {
             urls = classLoader.getResources(normalizedPath + type.getName());
         } catch (IOException ioe) {
+            LOG.error(ioe.getClass().getName() + " error loading resources of type \"" + type.getName() + "\" from \"" + normalizedPath + "\".");
             return false;
         }
 


### PR DESCRIPTION
We use Java webstart to distribute a client application to near 2000 customers of a radio show distributor; the downloaders then further sub-distribute to even more stations. They are practically all on various Windows versions but the code works in certain Linux distributions and we also develop in Linux. We have been using Griffon 1 for this for some years and it is great but during the current upgrade to Griffon 2 there was a very strange problem running the code in Windows. The problem eventually came down to model/view/controller classes not being detected and loaded. There was no logging of the number of different Griffon artifact classes being loaded at all. In Linux it worked fine.

It turned out that the problem was that java.lang.Classloader.getResource only accepts '/' as separator and the griffon ServiceLoaderUtils.load method used File.separator - which of course is backslash in Windows. Now this took some looking to find but the code change is quite small and I actually think that it could have been fixed by not touching the incoming path at all since all calls that I found already had a slash at the end.

There are free official virtual machines of various Windows versions available on https://www.modern.ie/  for testing. We tested the code in this pull request by compiling griffon locally and forcing our version of griffon-core into a webstart distribution which we then ran in such a VM, so we feel sure that it at least works better than the File.separator version.

Thank you for your work on Griffon by the way, and for switching to Gradle.
