### PR TITLE
Add support to ScrollPane as root of a fxml

### DIFF
--- a/samples/editor-javafx-java/griffon-app/resources/editor/container.fxml
+++ b/samples/editor-javafx-java/griffon-app/resources/editor/container.fxml
@@ -23,27 +23,32 @@
 <?import javafx.scene.control.SeparatorMenuItem?>
 <?import javafx.scene.control.TabPane?>
 <?import javafx.scene.layout.BorderPane?>
-<BorderPane maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="400.0"
-            prefWidth="600.0" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1"
-            fx:controller="editor.ContainerController">
-    <top>
-        <MenuBar BorderPane.alignment="CENTER">
-            <menus>
-                <Menu mnemonicParsing="false" text="File">
-                    <items>
-                        <MenuItem mnemonicParsing="false" text="Open" fx:id="openActionTarget"/>
-                        <MenuItem mnemonicParsing="false" text="Close" fx:id="closeActionTarget"/>
-                        <SeparatorMenuItem mnemonicParsing="false"/>
-                        <MenuItem mnemonicParsing="false" text="Save" fx:id="saveActionTarget"/>
-                        <SeparatorMenuItem mnemonicParsing="false"/>
-                        <MenuItem mnemonicParsing="false" text="Quit" fx:id="quitActionTarget"/>
-                    </items>
-                </Menu>
-            </menus>
-        </MenuBar>
-    </top>
-    <center>
-        <TabPane fx:id="tabGroup" prefHeight="200.0" prefWidth="200.0" tabClosingPolicy="UNAVAILABLE"
-                 BorderPane.alignment="CENTER"/>
-    </center>
-</BorderPane>
+
+<?import javafx.scene.control.ScrollPane?>
+<ScrollPane xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1"
+            fx:controller="editor.ContainerController" fitToHeight="true" fitToWidth="true"
+            vbarPolicy="AS_NEEDED" hbarPolicy="AS_NEEDED">
+    <BorderPane maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="400.0"
+                prefWidth="600.0">
+        <top>
+            <MenuBar BorderPane.alignment="CENTER">
+                <menus>
+                    <Menu mnemonicParsing="false" text="File">
+                        <items>
+                            <MenuItem mnemonicParsing="false" text="Open" fx:id="openActionTarget"/>
+                            <MenuItem mnemonicParsing="false" text="Close" fx:id="closeActionTarget"/>
+                            <SeparatorMenuItem mnemonicParsing="false"/>
+                            <MenuItem mnemonicParsing="false" text="Save" fx:id="saveActionTarget"/>
+                            <SeparatorMenuItem mnemonicParsing="false"/>
+                            <MenuItem mnemonicParsing="false" text="Quit" fx:id="quitActionTarget"/>
+                        </items>
+                    </Menu>
+                </menus>
+            </MenuBar>
+        </top>
+        <center>
+            <TabPane fx:id="tabGroup" prefHeight="200.0" prefWidth="200.0" tabClosingPolicy="UNAVAILABLE"
+                     BorderPane.alignment="CENTER"/>
+        </center>
+    </BorderPane>
+</ScrollPane>

--- a/subprojects/griffon-javafx/src/main/java/griffon/javafx/support/JavaFXUtils.java
+++ b/subprojects/griffon-javafx/src/main/java/griffon/javafx/support/JavaFXUtils.java
@@ -28,18 +28,7 @@ import javafx.event.EventHandler;
 import javafx.scene.Node;
 import javafx.scene.Parent;
 import javafx.scene.Scene;
-import javafx.scene.control.Accordion;
-import javafx.scene.control.ButtonBase;
-import javafx.scene.control.Control;
-import javafx.scene.control.Labeled;
-import javafx.scene.control.Menu;
-import javafx.scene.control.MenuBar;
-import javafx.scene.control.MenuItem;
-import javafx.scene.control.SplitPane;
-import javafx.scene.control.Tab;
-import javafx.scene.control.TabPane;
-import javafx.scene.control.TitledPane;
-import javafx.scene.control.Tooltip;
+import javafx.scene.control.*;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
 import javafx.scene.input.KeyCombination;
@@ -456,6 +445,10 @@ public final class JavaFXUtils {
                 Object found = findElement(child, id);
                 if (found != null) return found;
             }
+        } else if (root instanceof ScrollPane) {
+            ScrollPane scrollPane = (ScrollPane) root;
+            Object found = findElement(scrollPane.getContent(), id);
+            if (found != null) return found;
         } else if (root instanceof Parent) {
             Parent parent = (Parent) root;
             for (Node child : parent.getChildrenUnmodifiable()) {


### PR DESCRIPTION
The method connectActions dont work when the root of fxml is one ScrollPane.

To show this bug i change the file container.fxml of project editor-javafx-java, now root is one ScrollPane, and change JavaFXUtils to support ScrollPane how root element.

