### PR TITLE
Moved versioning plugin to the root only.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,6 @@ buildScan {
 apply from: 'gradle/idea.gradle'
 apply plugin: 'jacoco'
 apply plugin: 'com.github.kt3k.coveralls'
-apply plugin: 'net.nemerosa.versioning'
 
 jacoco {
     toolVersion = jacocoVersion

--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,7 @@ buildScan {
 apply from: 'gradle/idea.gradle'
 apply plugin: 'jacoco'
 apply plugin: 'com.github.kt3k.coveralls'
+apply plugin: 'net.nemerosa.versioning'
 
 jacoco {
     toolVersion = jacocoVersion

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -18,6 +18,7 @@ if (!publishJars.toBoolean()) return
 
 apply plugin: 'maven-publish'
 apply plugin: 'com.jfrog.bintray'
+apply plugin: 'net.nemerosa.versioning'
 
 def pomConfig = {
     name project.name

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -18,7 +18,6 @@ if (!publishJars.toBoolean()) return
 
 apply plugin: 'maven-publish'
 apply plugin: 'com.jfrog.bintray'
-apply plugin: 'net.nemerosa.versioning'
 
 def pomConfig = {
     name project.name
@@ -91,8 +90,9 @@ publishing {
 }
 
 jar {
-    manifest {
-        attributes(
+    doFirst {
+        manifest {
+            attributes(
             'Built-By': System.properties['user.name'],
             'Created-By': "${System.properties['java.version']} (${System.properties['java.vendor']} ${System.properties['java.vm.version']})".toString(),
             'Build-Date': buildDate,
@@ -104,7 +104,8 @@ jar {
             'Implementation-Title': project.name,
             'Implementation-Version': project.version,
             'Implementation-Vendor': 'griffon-framework.org'
-        )
+            )
+        }
     }
 
     metaInf {


### PR DESCRIPTION
Moved versioning plugin to the root only making versioning still resolvable by sub-projects, but evaluating the info only once. As the evaluation is happened on the configuration time,
this change speeds up the configuration time with a few seconds (4-7 for me). 

The evaluation of that info also has been pushed into the execution
phase, at least for the jar task.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/griffon/griffon/174)
<!-- Reviewable:end -->
