### PR TITLE
Update plugin-publish-plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ buildscript {
         classpath 'org.kordamp.gradle:clirr-gradle-plugin:0.2.3'
         classpath 'net.nemerosa:versioning:2.6.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
-        classpath 'com.gradle.publish:plugin-publish-plugin:0.9.3'
+        classpath 'com.gradle.publish:plugin-publish-plugin:0.9.9'
         classpath 'gradle.plugin.net.ossindex:ossindex-gradle-plugin:0.1.1'
         classpath 'org.kordamp.gradle:jdeps-gradle-plugin:0.2.0'
         classpath 'com.gradle:build-scan-plugin:1.8'


### PR DESCRIPTION
Hiya, I was doing a scan of the Gradle Plugin Portal and noticed you are using an old version of the `plugin-publish-plugin`.

There was a [bug in versions prior to 0.9.7](https://discuss.gradle.org/t/plugin-authors-please-use-the-latest-plugin-publish-plugin-others-may-result-in-a-broken-upload/23573), where artifacts would silently not be pushed into the repo, which means the latest versions of your plugins do not work properly when people apply it to their build.

https://plugins.gradle.org/plugin/org.codehaus.griffon.griffon
https://plugins.gradle.org/plugin/org.codehaus.griffon.griffon-build

Upgrading to the latest version of the `plugin-publish-plugin` will fix this, but this will require pushing a new version of your plugin.

1. apply the PR
2. publish a new version of your plugin
3. let us know if you want us to remove the broken version `2.12.0`

Thanks (and sorry about that).

Let me know here [or in the forums](https://discuss.gradle.org/c/help-discuss/plugin-portal) if you need more assistance.

Tim

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/griffon/griffon/272)
<!-- Reviewable:end -->
